### PR TITLE
Fix issue revalidation path

### DIFF
--- a/app/(kiosk dashboard)/dashboard/issues/[id]/newIssueFormServerActions.ts
+++ b/app/(kiosk dashboard)/dashboard/issues/[id]/newIssueFormServerActions.ts
@@ -27,8 +27,8 @@ export async function createNewIssueFormAction(_formState: CreateNewIssueFormSta
 		};
 	}
 
-	// revalidate the /issue/{kioskId} page for the kiosk
-	revalidatePath(`/issue/${ticket.kioskId}`);
+        // revalidate the /dashboard/issues/{kioskId} page for the kiosk
+        revalidatePath(`/dashboard/issues/${ticket.kioskId}`);
 
 	return {
 		status: 'success'


### PR DESCRIPTION
## Summary
- revalidate `/dashboard/issues/{kioskId}` instead of `/issue/{kioskId}` in `newIssueFormServerActions`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684879f3663883329c89d6d701f73085